### PR TITLE
Notify RSC about updated permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Lookup the instance profiles and roles needed for the specified RSC features.
 data "polaris_aws_cnp_artifacts" "artifacts" {
-  cloud    = var.rsc_cloud_type
+  cloud = var.rsc_cloud_type
 
   dynamic "feature" {
     for_each = var.rsc_aws_features
@@ -20,7 +20,7 @@ data "polaris_aws_cnp_permissions" "permissions" {
   ec2_recovery_role_path = var.aws_ec2_recovery_role_path
   role_key               = each.key
 
-    dynamic "feature" {
+  dynamic "feature" {
     for_each = var.rsc_aws_features
     content {
       name              = feature.value["name"]
@@ -95,8 +95,9 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
   dynamic "role" {
     for_each = aws_iam_role.rsc_roles
     content {
-      key = role.key
-      arn = role.value["arn"]
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
     }
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,19 +2,19 @@ terraform {
   required_version = ">=1.5.6"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~>5.26.0"
     }
     polaris = {
       source  = "rubrikinc/polaris"
-      version = "=0.8.0-beta.16"
+      version = "=0.10.0-beta.9"
     }
   }
 }
 
 provider "aws" {
   retry_mode = "standard"
-  profile = var.aws_profile
+  profile    = var.aws_profile
 }
 
 provider "polaris" {


### PR DESCRIPTION
# Description

Use the permissions field of the polaris_aws_cnp_account_attachments' role field to notify RSC about updated permissions.

## Motivation and Context

This change makes it so that RSC will be notified about updated permissions moving the cloud account from the missing permissions state in the UI.

## How Has This Been Tested?

Tested with a cloud account missing permissions for the cross account role of the cloud native protection feature.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
