### PR TITLE
Fix duplicate policy name collision in customer_managed_policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.5.3
 * Fix the Module tag in the basic example.
 * Change the type of the `aws_regions` variable from `list(string)` to `set(string)`.
+* Fix a bug where two RSC policies sharing a name within the same role artifact caused a Terraform duplicate-key
+  error. Colliding policies are now suffixed with a short hash of the policy body.
 
 ## v0.5.2
 * Update changelog.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ module "cloud_native" {
 ### v0.5.3
 * Fix the Module tag in the basic example.
 * Change the type of the `aws_regions` variable from `list(string)` to `set(string)`.
+* Fix a bug where two RSC policies sharing a name within the same role artifact caused a Terraform duplicate-key
+  error. Colliding policies are now suffixed with a short hash of the policy body.
 
 ### v0.5.2
 * Update changelog.
@@ -88,7 +90,7 @@ removed.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.26.0 |
 | <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.0.0 |
@@ -96,14 +98,14 @@ removed.
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >=5.26.0 |
 | <a name="provider_polaris"></a> [polaris](#provider\_polaris) | >=1.0.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_instance_profile.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.customer_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.customer_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -126,7 +128,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID to protect with Rubrik Security Cloud. | `string` | n/a | yes |
 | <a name="input_aws_account_name"></a> [aws\_account\_name](#input\_aws\_account\_name) | AWS account name to protect with Rubrik Security Cloud. | `string` | n/a | yes |
 | <a name="input_aws_ec2_recovery_role_path"></a> [aws\_ec2\_recovery\_role\_path](#input\_aws\_ec2\_recovery\_role\_path) | EC2 recovery role path for the cross account role. | `string` | `""` | no |
@@ -144,7 +146,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_aws_eks_worker_node_role_arn"></a> [aws\_eks\_worker\_node\_role\_arn](#output\_aws\_eks\_worker\_node\_role\_arn) | n/a |
 | <a name="output_aws_iam_cross_account_role_arn"></a> [aws\_iam\_cross\_account\_role\_arn](#output\_aws\_iam\_cross\_account\_role\_arn) | n/a |
 | <a name="output_cluster_master_role_arn"></a> [cluster\_master\_role\_arn](#output\_cluster\_master\_role\_arn) | n/a |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -17,7 +17,7 @@ resources.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.26.0 |
 | <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.0.0 |
 
@@ -32,13 +32,13 @@ No resources.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_cloud_native"></a> [cloud\_native](#module\_cloud\_native) | ../.. | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID. | `string` | n/a | yes |
 | <a name="input_aws_account_name"></a> [aws\_account\_name](#input\_aws\_account\_name) | AWS account name. | `string` | n/a | yes |
 | <a name="input_aws_regions"></a> [aws\_regions](#input\_aws\_regions) | AWS regions. | `set(string)` | n/a | yes |

--- a/iam_policy.tf
+++ b/iam_policy.tf
@@ -1,9 +1,18 @@
 locals {
+  # When two policies in the same RSC role artifact share a name, suffix the
+  # colliding entries with a short hash of the policy body to keep map keys
+  # unique. Names that don't collide pass through unchanged.
   customer_managed_policies = merge([
     for key, value in data.polaris_aws_cnp_permissions.permissions : {
-      for policy in value.customer_managed_policies : policy.name => {
-        role_key = key,
-        policy   = policy.policy,
+      for p in value.customer_managed_policies : (
+        # A count higher than 1 means there is a collision and the key is
+        # suffixed with a short hash of the body; a count of 1 means p is the
+        # only policy with that name, so the bare name is safe to use as the
+        # key.
+        length([for v in value.customer_managed_policies : v if v.name == p.name]) > 1 ? "${p.name}-${substr(sha256(p.policy), 0, 8)}" : p.name
+      ) => {
+        role_key = key
+        policy   = p.policy
       }
     }
   ]...)
@@ -109,6 +118,6 @@ resource "aws_iam_role_policy_attachments_exclusive" "customer_managed" {
 
   policy_arns = concat(
     each.value.managed_policies,
-    [for policy in each.value.customer_managed_policies : aws_iam_policy.customer_managed[policy.name].arn]
+    [for k, v in local.customer_managed_policies : aws_iam_policy.customer_managed[k].arn if v.role_key == each.key]
   )
 }


### PR DESCRIPTION
# Description

The `customer_managed_policies` local in `iam_policy.tf` builds a flat map keyed by `policy.name`. RSC can return two customer-managed policies with the same name within a single role artifact, which hits Terraform's duplicate-key error and aborts the apply.

This change suffixes only the colliding entries with the first 8 characters of `sha256(policy.policy)`. Names that don't collide pass through unchanged, so existing customer state is preserved. The `aws_iam_role_policy_attachments_exclusive.customer_managed` lookup now filters the flat local by `role_key` instead of looking up by raw `policy.name`, so the disambiguation rule lives in exactly one place.

Same fix as rubrikinc/terraform-provider-polaris-examples#93.

## Related Issue

_None._

## Motivation and Context

Without this fix, any tenant where RSC returns same-named customer-managed policies in a single role artifact cannot apply this module. After the fix, those tenants get one AWS IAM policy per distinct body, while unaffected tenants see no state churn.

## How Has This Been Tested?

* End-to-end against an RSC tenant without collisions to confirm no state churn for unaffected tenants.
* Offline using a mock that reproduces the colliding `ExocomputePolicy` entries observed under `CROSSACCOUNT`, to verify the merge expression produces the expected disambiguated keys.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.