### PR TITLE
Update basic example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.3
+* Fix the Module tag in the basic example.
+* Change the type of the `aws_regions` variable from `list(string)` to `set(string)`.
+
 ## v0.5.2
 * Update changelog.
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,20 @@ module "cloud_native" {
 
 ## Changelog
 
-# v0.5.2
+### v0.5.3
+* Fix the Module tag in the basic example.
+* Change the type of the `aws_regions` variable from `list(string)` to `set(string)`.
+
+### v0.5.2
 * Update changelog.
 
-# v0.5.1
+### v0.5.1
 * Make use of the `permissions` field in the `polaris_aws_cnp_account_attachments` resource to trigger an update of the
   resource whenever the permissions changes. This update will move the RSC cloud account from the missing permissions
   state. See the RSC (polaris) provider [upgrade guide](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/guides/upgrade_guide_v1.0.0#new-permissions-field)
   for additional information.
 
-# v0.5.0
+### v0.5.0
 * Relax the AWS provider version constraint to `>=5.26.0`.
 * Relax the RSC (Polaris) provider version constraint to `>=1.0.0`.
 * Remove the AWS and RSC (Polaris) provider blocks from the module. These must now be provided in the Terraform root

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -41,7 +41,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID. | `string` | n/a | yes |
 | <a name="input_aws_account_name"></a> [aws\_account\_name](#input\_aws\_account\_name) | AWS account name. | `string` | n/a | yes |
-| <a name="input_aws_regions"></a> [aws\_regions](#input\_aws\_regions) | AWS regions. | `list(string)` | n/a | yes |
+| <a name="input_aws_regions"></a> [aws\_regions](#input\_aws\_regions) | AWS regions. | `set(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -22,7 +22,7 @@ variable "aws_account_name" {
 }
 
 variable "aws_regions" {
-  type        = list(string)
+  type        = set(string)
   description = "AWS regions."
 }
 
@@ -63,6 +63,6 @@ module "cloud_native" {
   tags = {
     Environment = "test"
     Example     = "basic"
-    Module      = "terraform-aws-polaris-cloud-native-exocompute-networking"
+    Module      = "terraform-aws-polaris-cloud-native"
   }
 }


### PR DESCRIPTION
# Description

Two changes to the `aws_iam_account` basic example:

* Fix the `Module` tag, which was set to `terraform-aws-polaris-cloud-native-exocompute-networking`. It now matches this module: `terraform-aws-polaris-cloud-native`.
* Change the type of the example's `aws_regions` variable from `list(string)` to `set(string)`, matching the module's `aws_regions` input.

The top-level `README.md` also gets a changelog formatting fix: the version sub-headers are demoted from h1 to h3 so they nest under the `## Changelog` h2.

## Related Issue

_None._

## Motivation and Context

The `Module` tag was misleading anyone inspecting the AWS resources created by the basic example. The variable type mismatch was inconsistent with the module's input type.

## How Has This Been Tested?

* Ran `terraform plan` against the basic example after the changes.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.